### PR TITLE
Fixed Navbar background color

### DIFF
--- a/.vuepress/override.styl
+++ b/.vuepress/override.styl
@@ -3,7 +3,8 @@ $textColor = #2c3e50
 $borderColor = #eaecef
 $codeBgColor = #282c34
 
-header.navbar
+header.navbar,
+header.navbar .links
   background-color: #2c3e50
 
 .navbar .site-name, .nav-links .nav-item, 


### PR DESCRIPTION
The link section of the Navbar had a white background, different from the rest of the navbar. 

<img width="1079" alt="screen shot 2018-10-10 at 16 58 43" src="https://user-images.githubusercontent.com/1895474/46762615-ecdb3e80-ccad-11e8-8fd7-c8ca887c0149.png">
