### PR TITLE
Add semicolon to methods block

### DIFF
--- a/workshop/ch6.md
+++ b/workshop/ch6.md
@@ -128,7 +128,7 @@ methods: {
       http.request({
         url: "https://dog.ceo/api/breeds/image/random/15", method: "GET"
       }).then((response) => {
-        this.dogArray = JSON.parse(response.content)
+        this.dogArray = JSON.parse(response.content);
         for (let i = 0; i < 15; i++) {
           this.dogs.push(this.dogArray.message[i])
         }


### PR DESCRIPTION
The NativeScript playground threw errors until I added a semicolon at line 131 to separate `this.dogArray = JSON.parse(response.content)` and `for (let i = 0; i < 15; i++)`