### PR TITLE
updated entrypoint to match the newer syntax

### DIFF
--- a/workshop/full-day/ch4.md
+++ b/workshop/full-day/ch4.md
@@ -150,12 +150,10 @@ Then add the `store` to the Vue instance properties in `main.js`:
 
 ```js
 new Vue({
-	el: "#app",
-	components: { App },
-	template: "<App/>",
-	router,
-	store
-});
+  router,
+  store,
+  render: h => h(App)
+}).$mount("#app");
 ```
 
 Now all the components in the application will have access to our state via `this.$store.state` placed inside any component's computed property. Let's try to access it from the `Favorites` component.


### PR DESCRIPTION
```
new Vue({
  router,
  store,
  render: h => h(App)
}).$mount("#app");
```