### PR TITLE
Improve code blocks and instructions in Chapter 3

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -78,4 +78,7 @@ module.exports = {
 			},
 		},
 	},
+	markdown: {
+    lineNumbers: true
+  }
 };

--- a/workshop/full-day/ch3.md
+++ b/workshop/full-day/ch3.md
@@ -22,13 +22,13 @@ Originally, Vue supported its own way of making API calls using .ajax; but this 
 
 First, add Axios's library to your project dependencies. To do so in Code Sandbox, click on `File Editor` tab -> `Dependencies` -> `Add Dependency` and search for `axios`
 
-Import axios into the component where we will perform our API call - `views/Pets.vue`. In that component's script block, add this line:
+Import axios into the component where we will perform our API call - `views/Pets.vue`. In that component's script block (right after `<script>`), add this line:
 
 ```js
 import axios from "axios";
 ```
 
-All our calls will use the same base URL with different endpoints. Right under the import for axios, add the base URL to Axios' options:
+All our calls will use the same base URL with different endpoints. Right under the import for axios, add the base URL to Axios' options in `views/Pets.vue`:
 
 ```js
 axios.defaults.baseURL = "https://dog.ceo/api";
@@ -40,7 +40,7 @@ Now we are ready to make our first API call.
 
 Let's replace the first static image with the random Husky picture from the Dog CEO API. First we have to check which endpoint we have to use. Looking at the API's [documentation](https://dog.ceo/dog-api/) we can find out that we need to append `/breed/husky/images/random` to the base API call (the `api` part is already in our base URL).
 
-We want a new image to replace the old one right when the component is created, so let's add a `created()` hook after the `data()` property:
+We want a new image to replace the old one right when the component is created, so let's add a `created()` hook after the `data()` property (in `views/Pets.vue`):
 
 ```js
 ...
@@ -57,9 +57,10 @@ Note: Make sure to add a comma after the data object and then add the created() 
 This is our app's first lifecycle hook! These are very useful when you want fine control over when to run blocks of code. Read more [here](https://vuejs.org/v2/guide/instance.html#Instance-Lifecycle-Hooks)
 :::
 
-Inside the created hook we will add our first query to the API. To perform a GET request Axios uses the `axios.get` method. The result will be a JavaScript promise, so we have to provide success and failure callbacks to it. For now, let's simply print the query result to console. Edit `created(){}` by placing this snippet between the curly brackets:
+Inside the created hook we will add our first query to the API. To perform a GET request Axios uses the `axios.get` method. The result will be a JavaScript promise, so we have to provide success and failure callbacks to it. For now, let's simply print the query result to console. Inside `created(){}` place this highlighted axios snippet (lines 2-9):
 
-```js
+```js {2-9}
+created() {
   axios
     .get("/breed/husky/images/random")
     .then(response => {
@@ -68,23 +69,44 @@ Inside the created hook we will add our first query to the API. To perform a GET
     .catch(error => {
       console.log(error);
     });
+  }
 ```
 
 In the browser view in Code Sandbox, switch to the Pets tab. You should see an object in your console. Drill into it by clicking its left-hand arrow. We are interested in its `data` field. You can see we have a status `success` and a message with an image URL (you can copy/paste it to your browser and discover a cute Husky).
 
 ## Use the API 1 - Replace Some of the Static Data
 
-Let's replace our Husky image with this new one. First, we should find a Husky in our dogs array with an `Array.find` method. It will check the `dogs` array items that we are already loading into the component from the `data/dogs.js` data file one by one to find the first item matching provided criteria. In our case the criteria is a `breed` equal to `husky`. Replace the `console.log()` inside the `then` callback in the Axios call we just implemented with this string:
+Let's replace our Husky image with this new one. First, we should find a Husky in our dogs array with an `Array.find` method. It will check the `dogs` array items that we are already loading into the component from the `data/dogs.js` data file one by one to find the first item matching provided criteria. In our case the criteria is a `breed` equal to `husky`. Replace the `console.log()` inside the `then` callback in the Axios call we just implemented with the highlighted lines (5-6):
 
-```js
-const husky = this.dogs.find(dog => dog.breed === 'husky');
-console.log(husky);
+```js {5-6}
+created() {
+  axios
+    .get("/breed/husky/images/random")
+    .then(response => {
+      const husky = this.dogs.find(dog => dog.breed === 'husky');
+      console.log(husky);
+    })
+    .catch(error => {
+      console.log(error);
+    });
+  }
 ```
 
-Ok, we have found a husky, which you can see in the `console.log()`. You can also see him in your app's Pets page - look for 'Max', listed as a husky. Now let's provide him with a new image by reassigning the image url from the static data to data coming from the API. Add this line under the snippet you just added.
+Ok, we have found a husky, which you can see in the `console.log()`. You can also see him in your app's Pets page - look for 'Max', listed as a husky. Now let's provide him with a new image by reassigning the image url from the static data to data coming from the API. Add the highlighted line (7) under the lines you just added above.
 
-```js
-husky.img = response.data.message;
+```js {7}
+created() {
+  axios
+    .get("/breed/husky/images/random")
+    .then(response => {
+      const husky = this.dogs.find(dog => dog.breed === 'husky');
+      console.log(husky);
+      husky.img = response.data.message;
+    })
+    .catch(error => {
+      console.log(error);
+    });
+  }
 ```
 
 You should see the image change to a random husky image pulled from the Dog CEO API.
@@ -97,20 +119,38 @@ Let's try to load a random image for each dog in our `dogs` array. The first thi
 The `map()` method creates a new array with the results of calling a provided function on every element in the calling array.
 :::
 
-Overwrite the code in the `created()`...`.then` by creating this linksArray constant:
+To create an array of links, we create a linksArray constant and add it inside the `created()` hook, like this (lines 2-4):
 
-```js
-const linksArray = this.dogs.map(
-   dog => "/breed/" + dog.breed + "/images/random"
-);
+```js {2-4}
+created() {
+  const linksArray = this.dogs.map(
+        dog => "/breed/" + dog.breed + "/images/random"
+      );
+  axios
+    .get("/breed/husky/images/random")
+    .then(response => {
+      const husky = this.dogs.find(dog => dog.breed === 'husky');
+      console.log(husky);
+      husky.img = response.data.message;
+    })
+    .catch(error => {
+      console.log(error);
+    });
+  }
 ```
 
 We're taking the breed of each dog in the array and inserting it inside the endpoint string (we used the same one previously for husky, but `breed` was hard-coded to a static value there).
 
-At this point, we have to perform multiple API calls using all the links we've just created - as many API calls as exist in our static data. Axios has helper functions for this case called `axios.all` and `axios.spread`. We will provide an array of our requests to the first one; it will return an array of responses and we should use `axios.spread` to spread this array into multiple arguments. To create an array of queries we will use a `.map` method on our `linksArray`, performing `axios.get` for each link. Add this snippet right under the linksArray snippet you added just before.
+At this point, we have to perform multiple API calls using all the links we've just created in our `linksArray` constant - as many API calls exist in our static data. To help us do this, axios has helper functions called `axios.all` and `axios.spread`.
 
-```js
-axios.all(linksArray.map(link => axios.get(link)))
+We will provide an array of our requests to the first one, `axios.all`; it will return an array of responses and we should use `axios.spread` to spread this array into multiple arguments. To create an array of queries we will use a `.map` method on our `linksArray`, performing `axios.get` for each link. Add this snippet (lines 8-16) right under the linksArray snippet you added just before.
+
+```js {5-12}
+created() {
+  const linksArray = this.dogs.map(
+        dog => "/breed/" + dog.breed + "/images/random"
+      );
+  axios.all(linksArray.map(link => axios.get(link)))
    .then(
      axios.spread((...res) => {
        this.dogs.forEach((dog, index) => {
@@ -118,6 +158,7 @@ axios.all(linksArray.map(link => axios.get(link)))
        });
      })
    );
+  }
 ```
 
 ::: tip 💡
@@ -126,12 +167,25 @@ What's going on here? The forEach() method executes a provided function once for
 
 Now we have new images each time our `Pets` component is created (you can see the images change on page refresh or simply by switching the tabs from `pets` to `home` and back). The dogs' names and breeds are still being drawn from static data, but the images are coming from the API, matched with the static dog's breed.
 
-The only remaining problem is that we can still see old images for a short moment when we enter the pets tab. Let's clear the dogs images before we perform a query. Add this code as the first one inside the `created()` hook:
+The only remaining problem is that we can still see old images for a short moment when we enter the pets tab. Let's clear the dogs images before we perform a query. Add this code (lines 2-4) at the start of the `created()` hook (lines 2-4):
 
-```js
-this.dogs.forEach(dog => {
+```js {2-4}
+created() {
+  this.dogs.forEach(dog => {
      dog.img = "";
-});
+  });
+  const linksArray = this.dogs.map(
+        dog => "/breed/" + dog.breed + "/images/random"
+      );
+  axios.all(linksArray.map(link => axios.get(link)))
+   .then(
+     axios.spread((...res) => {
+       this.dogs.forEach((dog, index) => {
+         dog.img = res[index].data.message;
+       });
+     })
+   );
+}
 ```
 
 **Now we initially see empty dog portraits and then images are loaded from the API. Progress!**


### PR DESCRIPTION
Feedback from this chapter has been that the instructions have been unclear. 
Most of the mistakes we have had to help with involves putting back deleted code that shouldn't have been deleted. 

This PR improves some explanations that attendees think was unclear and hard to understand, as well as adding line numbers and line highlighting to code blocks and code around the snippets that are supposed to be inserted.