### PR TITLE
Add copy button for each code block

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,3 +1,5 @@
+const addCopyButton = require('./copyButton');
+
 module.exports = {
 	base: '/',
 	head: [['link', { rel: 'icon', href: '/favicon.png' }]],
@@ -106,5 +108,8 @@ module.exports = {
 	},
 	markdown: {
 		lineNumbers: true,
+		extendMarkdown: (md) => {
+			addCopyButton(md);
+		}
 	},
 };

--- a/.vuepress/copyButton.js
+++ b/.vuepress/copyButton.js
@@ -1,0 +1,35 @@
+/**
+ * Add a copy button to the top of each code section
+ */
+module.exports = (md) => {
+  // Not sure how else to add this javascript to the page
+  const copy = `
+  <script>
+    function copyText(event, node) {
+      // So we don't go anywhere
+      event.preventDefault();
+
+      const toCopy = node.parentElement.nextElementSibling.querySelector('code');
+      const el = document.createElement('textarea');
+      el.value = toCopy.innerText;
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+    }
+  </script>
+  `;
+
+  // Define our button and some styling
+  const button = `
+  <div style="display: flex; justify-content: flex-end;">
+  <a href="#" onclick="copyText(event, this)">
+  Copy
+  </a>
+  </div>
+  `;
+
+  // Replace the markdown rule with a new one that prepends the button
+  const fence = md.renderer.rules.fence;
+  md.renderer.rules.fence = (...args) => `${copy}${button}${fence(...args)}`;
+};

--- a/.vuepress/copyButton.js
+++ b/.vuepress/copyButton.js
@@ -23,9 +23,9 @@ module.exports = (md) => {
   // Define our button and some styling
   const button = `
   <div style="display: flex; justify-content: flex-end;">
-  <a href="#" onclick="copyText(event, this)">
-  Copy
-  </a>
+    <a href="#" onclick="copyText(event, this)">
+      Copy
+    </a>
   </div>
   `;
 


### PR DESCRIPTION
[![](https://cdn.vidyard.com/thumbnails/6276359/sl17YBQOe9yIN8gyfjVd7msS26gYVrSf.gif)](https://video.vidyard.com/watch/CLbVHNcoVntnwJCHPvrrV1?)

One of the workshop attendees was struggling to copy a large text block with only her trackpad, so I thought this would be a useful addition.

This approach is server-rendered, but I couldn't figure out how to only add the copy function in a single time without digging into something else. Dynamically adding this button in would be another solution and would let us use Vue, but this is pretty simple right now and it works 🤷‍♂ 

Thoughts?