### PR TITLE
Fix broken links to github repo in all the full-day workshops

### DIFF
--- a/workshops/vue/full-day/appendix_1.md
+++ b/workshops/vue/full-day/appendix_1.md
@@ -2,7 +2,7 @@
 
 Don't worry! At the beginning of each chapter, you are given a link to start fresh with a new sandbox. Below are instructions on how to create a new sandbox with this Github repo link.
 
-All the chapter links are kept [here](https://github.com/VueVixens/projects) - pick your chapter by saving its URL. For example, the downloadable link for Chapter 1 is [https://github.com/VueVixens/projects/tree/master/chapter-1-end](https://github.com/VueVixens/projects/tree/master/chapter-1-end).
+All the chapter links are kept [here](https://github.com/VueVixens/projects) - pick your chapter by saving its URL. For example, the downloadable link for Chapter 1 is [https://github.com/VueVixens/projects/tree/main/chapter-1-end](https://github.com/VueVixens/projects/tree/main/chapter-1-end).
 
 ::: tip 💡
 Ensure that you are logged into CodeSandbox.io so that you are able to keep your sandboxes in your account.

--- a/workshops/vue/full-day/ch2.md
+++ b/workshops/vue/full-day/ch2.md
@@ -3,7 +3,7 @@
 | **Project&nbsp;Goal**           | Learn how to manipulate data in a web app                                                                                                                                                                                                                          |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **What&nbsp;you’ll&nbsp;learn** | Using static data, you'll build a card interface to show many adoptable dogs                                                                                                                                                                                       |
-| **Tools&nbsp;you’ll&nbsp;need** | A modern browser like Chrome. An account in CodeSandbox.io. If you get lost, import the starting point for this chapter [here](https://github.com/VueVixens/projects/tree/master/chapter-1-end). Instructions on how to do this are in [Appendix 1](appendix_1.md) |
+| **Tools&nbsp;you’ll&nbsp;need** | A modern browser like Chrome. An account in CodeSandbox.io. If you get lost, import the starting point for this chapter [here](https://github.com/VueVixens/projects/tree/main/chapter-1-end). Instructions on how to do this are in [Appendix 1](appendix_1.md) |
 | **Time needed to complete**     | 1 hour                                                                                                                                                                                                                                                             |
 
 ## What You'll Build
@@ -12,7 +12,7 @@
 
 ## Instructions
 
-If you need to restart your project, clone [this repo](https://github.com/VueVixens/projects/tree/master/chapter-1-end) into Code Sandbox by clicking on the **Import from GitHub** link on the bottom left of the main page, and then pasting the repo's url into the fields. You can also continue with the project you've created in [chapter 1](ch1.md).
+If you need to restart your project, clone [this repo](https://github.com/VueVixens/projects/tree/main/chapter-1-end) into Code Sandbox by clicking on the **Import from GitHub** link on the bottom left of the main page, and then pasting the repo's url into the fields. You can also continue with the project you've created in [chapter 1](ch1.md).
 
 At this point, we have only a home page, but we want to add one more page to contain pet cards. Let's create a single-page application with a navigation bar listing "home" and "pets". Clicking on the "pets" page will bring us to the new page we're creating now and "home" will open the page we've created in [chapter 1](ch1.md).
 

--- a/workshops/vue/full-day/ch3.md
+++ b/workshops/vue/full-day/ch3.md
@@ -3,7 +3,7 @@
 | **Project&nbsp;Goal**           | Learn how API calls work and how to implement them in your web app                                                                                                                                                                                                 |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **What&nbsp;you’ll&nbsp;learn** | Using the [DogCEO API](https://dog.ceo/dog-api/) you will load dog images dynamically, instead of using dummy data                                                                                                                                                 |
-| **Tools&nbsp;you’ll&nbsp;need** | A modern browser like Chrome. An account in CodeSandbox.io. If you get lost, import the starting point for this chapter [here](https://github.com/VueVixens/projects/tree/master/chapter-2-end). Instructions on how to do this are in [Appendix 1](appendix_1.md) |
+| **Tools&nbsp;you’ll&nbsp;need** | A modern browser like Chrome. An account in CodeSandbox.io. If you get lost, import the starting point for this chapter [here](https://github.com/VueVixens/projects/tree/main/chapter-2-end). Instructions on how to do this are in [Appendix 1](appendix_1.md) |
 | **Time needed to complete**     | 1 hour                                                                                                                                                                                                                                                             |
 
 ## What You'll Build
@@ -12,7 +12,7 @@
 
 ## Instructions
 
-If you need to restart your project, clone [this repo](https://github.com/VueVixens/projects/tree/master/chapter-2-end) into Code Sandbox by clicking on the **Import from GitHub** link on the bottom left of the main page, and then pasting the repo's url into the fields. You can also continue with the project you've created in [chapter 2](ch2.md).
+If you need to restart your project, clone [this repo](https://github.com/VueVixens/projects/tree/main/chapter-2-end) into Code Sandbox by clicking on the **Import from GitHub** link on the bottom left of the main page, and then pasting the repo's url into the fields. You can also continue with the project you've created in [chapter 2](ch2.md).
 
 So far, we have placed images of dogs onto our screens via some static JSON data that we imported into a component. That's great for demo purposes, but in real life, you're almost always going to build web apps that consume real data that's coming from either your own data sources, or externally, from somewhere on the internet. Let's learn how to consume third-party data.
 

--- a/workshops/vue/full-day/ch4.md
+++ b/workshops/vue/full-day/ch4.md
@@ -3,7 +3,7 @@
 | **Project&nbsp;Goal**           | Create a tagging system for the shop so that you can add and remove a dog from your 'loyalty' list                                                                                                                                                                 |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **What&nbsp;you’ll&nbsp;learn** | State management in Vue application with Vuex                                                                                                                                                                                                                      |
-| **Tools&nbsp;you’ll&nbsp;need** | A modern browser like Chrome. An account in CodeSandbox.io. If you get lost, import the starting point for this chapter [here](https://github.com/VueVixens/projects/tree/master/chapter-3-end). Instructions on how to do this are in [Appendix 1](appendix_1.md) |
+| **Tools&nbsp;you’ll&nbsp;need** | A modern browser like Chrome. An account in CodeSandbox.io. If you get lost, import the starting point for this chapter [here](https://github.com/VueVixens/projects/tree/main/chapter-3-end). Instructions on how to do this are in [Appendix 1](appendix_1.md) |
 | **Time needed to complete**     | 1.5 hours                                                                                                                                                                                                                                                          |
 
 ## What You'll Build
@@ -12,7 +12,7 @@
 
 ## Instructions
 
-If you need to restart your project, clone [this repo](https://github.com/VueVixens/projects/tree/master/chapter-3-end) into Code Sandbox by clicking on the **Import from GitHub** link on the bottom left of the main page, and then pasting the repo's url into the fields. You can also continue with the project you've created in [chapter 3](ch3.md).
+If you need to restart your project, clone [this repo](https://github.com/VueVixens/projects/tree/main/chapter-3-end) into Code Sandbox by clicking on the **Import from GitHub** link on the bottom left of the main page, and then pasting the repo's url into the fields. You can also continue with the project you've created in [chapter 3](ch3.md).
 
 In this chapter, we will build a 'loyalty list' - like a shopping cart but for adoptions - to show the list of dogs that we particularly like and would like to adopt. To get started, create a new, blank file in the `views` folder and name it `Favorites.vue`.
 

--- a/workshops/vue/full-day/ch5.md
+++ b/workshops/vue/full-day/ch5.md
@@ -3,7 +3,7 @@
 | **Project&nbsp;Goal**           | Build a form to accept dummy 'checkout' data                                                                                                                                                                                                                       |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | **What&nbsp;you’ll&nbsp;learn** | How to create and validate forms in a Vue application                                                                                                                                                                                                              |
-| **Tools&nbsp;you’ll&nbsp;need** | A modern browser like Chrome. An account in CodeSandbox.io. If you get lost, import the starting point for this chapter [here](https://github.com/VueVixens/projects/tree/master/chapter-4-end). Instructions on how to do this are in [Appendix 1](appendix_1.md) |
+| **Tools&nbsp;you’ll&nbsp;need** | A modern browser like Chrome. An account in CodeSandbox.io. If you get lost, import the starting point for this chapter [here](https://github.com/VueVixens/projects/tree/main/chapter-4-end). Instructions on how to do this are in [Appendix 1](appendix_1.md) |
 | **Time needed to complete**     | 1 hour                                                                                                                                                                                                                                                             |
 
 ## What You'll Build
@@ -12,7 +12,7 @@
 
 ## Instructions
 
-If you need to restart your project, clone [this repo](https://github.com/VueVixens/projects/tree/master/chapter-4-end) into Code Sandbox by clicking on the **Import from GitHub** link on the bottom left of the main page, and then pasting the repo's url into the fields. You can also continue with the project you've created in [chapter 4](ch4.md).
+If you need to restart your project, clone [this repo](https://github.com/VueVixens/projects/tree/main/chapter-4-end) into Code Sandbox by clicking on the **Import from GitHub** link on the bottom left of the main page, and then pasting the repo's url into the fields. You can also continue with the project you've created in [chapter 4](ch4.md).
 
 In this chapter, we will create a form to fill after you finish selecting dogs. First of all, we should create a new component to contain this form and add a form route to our router settings.
 


### PR DESCRIPTION
Ensuring that all links to the example repo code are still valid 

Related to issue [#138](https://github.com/FrontEndFoxes/docs/issues/138)