### PR TITLE
152 gh readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,0 +1,4 @@
+# Github specific md file
+
+Experimenting to see whether the workaround in this issue will help:
+https://github.com/vuejs/vuepress/pull/23


### PR DESCRIPTION
This PR starts to address #152 - According to the workaround listed on the links in that issue, we may be able to use `README.markdown` to show a README on Github, which will will be geared toward potential contributors.